### PR TITLE
Rework the docker-compose and run scripts

### DIFF
--- a/_run.sh
+++ b/_run.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 NODE_AUTH_TOKEN=""
+OMDB_API_KEY=""
 ENVIRONMENT=""
 SERVICES="ionic_app nest_api poster_service metadata_service metadata_db"
 
@@ -10,29 +11,42 @@ for var in "$@"; do
     ENVIRONMENT=".prod"
     ;;
   "--init")
-    OMDB_API_KEY=""
     SERVICES=""
 
     echo "Please input a NODE_AUTH_TOKEN for access to the Github Package Registry:"
     read NODE_AUTH_TOKEN
-    echo $NODE_AUTH_TOKEN > node-auth.secret
+    echo $NODE_AUTH_TOKEN > node_auth.secret
 
     echo "Please input an OMDB API key for the poster-service"
     read OMDB_API_KEY
-    export OMDB_API_KEY
-    envsubst < docker-compose$ENVIRONMENT.yml > docker-compose$ENVIRONMENT.yml.secret
+    echo $OMDB_API_KEY > omdb_api.secret
     ;;
   esac
   shift
 done
 
-# if no auth token has been initialized yet, try to read it from secret
-if [ "$NODE_AUTH_TOKEN" = "" ]; then
-    NODE_AUTH_TOKEN=`cat node-auth.secret`
+if test -f "node_auth.secret"; then
+    NODE_AUTH_TOKEN=`cat node_auth.secret`
+    export NODE_AUTH_TOKEN
+fi
+
+if test -f "omdb_api.secret"; then
+    OMDB_API_KEY=`cat omdb_api.secret`
+    export OMDB_API_KEY
+fi
+
+if test -z "$NODE_AUTH_TOKEN"; then
+    echo "Please ensure that a valid NODE_AUTH_TOKEN is provided (run ./_run --init)"
+    exit
+fi
+
+if test -z "$OMDB_API_KEY"; then
+    echo "Please ensure that a valid OMDB_API_KEY is provided (run ./_run --init)"
+    exit
 fi
 
 # run a docker-compose build to ensure images are up-to-date
-docker-compose -f docker-compose$ENVIRONMENT.yml.secret build --parallel --build-arg NODE_AUTH_TOKEN=$NODE_AUTH_TOKEN
+docker-compose -f docker-compose$ENVIRONMENT.yml build --parallel
 
 # start the services as specified
-docker-compose -f docker-compose$ENVIRONMENT.yml.secret up $SERVICES
+docker-compose -f docker-compose$ENVIRONMENT.yml up $SERVICES

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -4,6 +4,8 @@ services:
     build:
       context: ionic-app
       dockerfile: Dockerfile.prod
+      args:
+        NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN}
     ports:
       - 3000:3000
     depends_on:
@@ -13,6 +15,8 @@ services:
     build:
       context: nest-api
       dockerfile: Dockerfile.prod
+      args:
+        NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN}
     environment:
       METADATA_SERVICE_URL: http://metadata_service:3003
       POSTER_SERVICE_URL: http://poster_service:3002
@@ -26,6 +30,8 @@ services:
     build:
       context: poster-service
       dockerfile: Dockerfile.prod
+      args:
+        NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN}
     environment:
       API_KEY: ${OMDB_API_KEY}
     ports:
@@ -35,6 +41,8 @@ services:
     build:
       context: metadata-service
       dockerfile: Dockerfile.prod
+      args:
+        NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN}
     environment:
       DATABASE_HOSTNAME: metadata_db
       DATABASE_URL: postgres://kwiz:kwiz@metadata_db:5432/kwiz

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,20 @@
 version: "3"
 services:
   ionic_app:
-    build: ionic-app
+    build:
+      context: ionic-app
+      args:
+        NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN}
     ports:
       - 3000:3000
     depends_on:
       - nest_api
 
   nest_api:
-    build: nest-api
+    build:
+      context: nest-api
+      args:
+        NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN}
     environment:
       METADATA_SERVICE_URL: http://metadata_service:3003
       POSTER_SERVICE_URL: http://poster_service:3002
@@ -19,14 +25,20 @@ services:
       - poster_service
 
   poster_service:
-    build: poster-service
+    build:
+      context: poster-service
+      args:
+        NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN}
     environment:
       API_KEY: ${OMDB_API_KEY}
     ports:
       - 3002:3002
 
   metadata_service:
-    build: metadata-service
+    build:
+      context: metadata-service
+      args:
+        NODE_AUTH_TOKEN: ${NODE_AUTH_TOKEN}
     environment:
       DATABASE_HOSTNAME: metadata_db
       DATABASE_URL: postgres://kwiz:kwiz@metadata_db:5432/kwiz


### PR DESCRIPTION
### Description

Rework `_run.sh` and the docker-compose definitions to not require any `envsubst` (docker-compose can do that already). Additionally, provide better errors and fail early if the necessary variables are not defined.

### Related Issues

None

### Checklist

- [x] Have you added tests where necessary? Do all the test pass? 
- [x] Have you added descriptive comments to your code?
- [x] Have you updated the documentation related to this propo
